### PR TITLE
Omada: re-auth on rejected token after controller reboot

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,51 @@
+name: Preview Docker Build
+
+on:
+  workflow_dispatch:
+    # Manual only — pick the branch from the Actions UI when you want a preview.
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    name: Build & Push :preview to Docker Hub (amd64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          platforms: linux/amd64
+          push: true
+          tags: |
+            applegater/status-server:preview
+            applegater/status-server:preview-${{ steps.sha.outputs.short }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "### Preview Build ✅" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image:** \`applegater/status-server:preview\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Pinned:** \`applegater/status-server:preview-${{ steps.sha.outputs.short }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Platform:** linux/amd64" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.4.1] — 2026-04-29 *(Omada token re-auth on controller reboot)*
+
+### Bug fix
+- **Omada checks stalled for up to ~2 hours after a controller reboot.** The status server caches the Omada Open API access token with the `expiresIn` value the controller hands back (default 7200s), but a controller reboot invalidates server-side tokens immediately. During the window between reboot and natural cache expiry, every check returned `"The access token has expired. Please re-initiate the refreshToken process to obtain the access token"` from Omada and surfaced that message in the dashboard "detail" field.
+- Fixed in **`backend/server.js`** — added `isOmadaTokenRejected()` (matches HTTP 401/403, errorCodes -44104/-44109/-44112/-44113, and a token/expired/refreshToken message regex) and refactored the standard + MSP API helpers through a shared `omadaAuthedGet()` that drops the cached token and retries once with a freshly issued one when the controller rejects the previous one. Both standard and MSP modes benefit.
+
+### Why an image rebuild
+Required for anyone using the Omada controller integration — without the fix, every Omada controller reboot causes a multi-hour outage in the Omada portion of the dashboard. Non-Omada checks are unaffected.
+
+### Also in this release
+- New **`.github/workflows/preview.yml`** — manual `workflow_dispatch` that builds `linux/amd64` only and pushes `applegater/status-server:preview` (plus a `preview-<short-sha>` pin) for Portainer-driven preview deploys ahead of a release.
+
+---
+
 ## [3.4.0] — HA / automatic failover feature removed
 
 The high-availability auto-failover work tracked in [issue #13](https://github.com/X4Applegate/status-server/issues/13) has been **fully removed** from the project. The code worked end-to-end — an end-to-end CF-driven failover drill did successfully promote the standby — but the operational complexity (bidirectional MariaDB replication, the promote webhook service, split-brain guard, Cloudflare Load Balancer + Notification policy, the post-failover resync procedure) is genuinely out of proportion to the uptime gains for a self-hosted status monitor.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ status.acmecorp.com {
 
 The server detects the `Host` header and serves the correct branded dashboard automatically.
 
+> **Using a commercial TLS cert (ZeroSSL, Sectigo, etc.) with Caddy UI?** You must upload the *full certificate chain*, not just the leaf. Node.js `fetch` inside containers will silently fail with `fetch failed` otherwise. See [docs/caddy-cert-renewal.md](./docs/caddy-cert-renewal.md) for why, how to spot the problem, and the exact commands to build `fullchain.pem`.
+
 ---
 
 ## License

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "status-server-backend",
-  "version": "3.3.5",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "status-server-backend",
-      "version": "3.3.5",
+      "version": "3.4.1",
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "ejs": "^5.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "status-server-backend",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Self-hosted server status monitor",
   "main": "server.js",
   "engines": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -1561,6 +1561,43 @@ async function omadaGetToken(controller) {
   return accessToken;
 }
 
+// True if an Omada response indicates the access token is no longer accepted
+// (e.g. controller was rebooted and invalidated server-side tokens before our
+// cache expiry says they should be gone). Match by both errorCode and message
+// text since codes vary across controller versions.
+function isOmadaTokenRejected(httpStatus, data) {
+  if (httpStatus === 401 || httpStatus === 403) return true;
+  if (!data) return false;
+  const code = Number(data.errorCode);
+  if (code === -44104 || code === -44109 || code === -44112 || code === -44113) return true;
+  const msg = String(data.msg || "").toLowerCase();
+  return msg.includes("access token") && (msg.includes("expired") || msg.includes("invalid") || msg.includes("refreshtoken"));
+}
+
+// Perform an authenticated GET against the Omada Open API. If the controller
+// rejects the cached token (e.g. after a controller reboot), drop the cache
+// and retry once with a freshly issued token.
+async function omadaAuthedGet(controller, fullUrl, label) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const token = await omadaGetToken(controller);
+    const r = await fetch(fullUrl, {
+      headers:    { Authorization: `AccessToken=${token}` },
+      dispatcher: omadaDispatcher(controller.verify_tls),
+      signal:     AbortSignal.timeout(8000)
+    });
+    let data = null;
+    try { data = await r.json(); } catch { /* non-JSON body */ }
+    if (r.ok && data && data.errorCode === 0) return data.result;
+    if (attempt === 0 && isOmadaTokenRejected(r.status, data)) {
+      delete omadaTokens[controller.id];
+      addLog({ level:"info", server:"omada", message:`Controller ${controller.id}: token rejected (${data?.msg || "HTTP " + r.status}); re-authenticating` });
+      continue;
+    }
+    if (!r.ok) throw new Error(`${label} HTTP ${r.status}`);
+    throw new Error((data && data.msg) || `${label} error`);
+  }
+}
+
 // Authenticated GET to /openapi/v1/{omadacId}<path>  (standard mode)
 async function omadaApiGet(controller, path) {
   const safeBase  = await sanitizeBaseUrl(controller.base_url);
@@ -1568,17 +1605,8 @@ async function omadaApiGet(controller, path) {
   // Sanitize each path segment to prevent traversal; preserve query string as-is
   const [pathOnly, queryString] = path.split("?");
   const safePath  = pathOnly.split("/").map(seg => seg.replace(/[^A-Za-z0-9\-_.:@!$&'()*+,;=~]/g, "")).join("/");
-  const token = await omadaGetToken(controller);
   const url   = `${safeBase}/openapi/v1/${safeId}${safePath}${queryString ? "?" + queryString : ""}`;
-  const r = await fetch(url, {
-    headers:    { Authorization: `AccessToken=${token}` },
-    dispatcher: omadaDispatcher(controller.verify_tls),
-    signal:     AbortSignal.timeout(8000)
-  });
-  if (!r.ok) throw new Error(`${path} HTTP ${r.status}`);
-  const data = await r.json();
-  if (data.errorCode !== 0) throw new Error(data.msg || `${path} error`);
-  return data.result;
+  return omadaAuthedGet(controller, url, path);
 }
 
 // Authenticated GET to /openapi/v1/msp/{mspId}<path>  (MSP mode — different URL shape)
@@ -1590,17 +1618,8 @@ async function omadaMspApiGet(controller, path) {
   // Sanitize each path segment to prevent traversal; preserve query string as-is
   const [pathOnly, queryString] = path.split("?");
   const safePath = pathOnly.split("/").map(seg => seg.replace(/[^A-Za-z0-9\-_.:@!$&'()*+,;=~]/g, "")).join("/");
-  const token = await omadaGetToken(controller);
   const url   = `${safeBase}/openapi/v1/msp/${mspId}${safePath}${queryString ? "?" + queryString : ""}`;
-  const r = await fetch(url, {
-    headers:    { Authorization: `AccessToken=${token}` },
-    dispatcher: omadaDispatcher(controller.verify_tls),
-    signal:     AbortSignal.timeout(8000)
-  });
-  if (!r.ok) throw new Error(`MSP ${path} HTTP ${r.status}`);
-  const data = await r.json();
-  if (data.errorCode !== 0) throw new Error(data.msg || `MSP ${path} error`);
-  return data.result;
+  return omadaAuthedGet(controller, url, `MSP ${path}`);
 }
 
 // Detect MSP vs standard mode by probing the actual MSP path documented for v6:

--- a/docs/caddy-cert-renewal.md
+++ b/docs/caddy-cert-renewal.md
@@ -1,0 +1,234 @@
+# Caddy TLS Cert — Full Chain Setup & Renewal
+
+If you proxy status-server through Caddy (or Caddy UI / nginx-proxy-manager style) and you upload your own TLS certificates from a commercial CA like **ZeroSSL**, **Sectigo**, **GoDaddy**, etc., you **must** paste the *full certificate chain* into Caddy — not just the leaf certificate.
+
+This doc explains why, how to spot the problem, and exactly what to do.
+
+---
+
+## Why this matters
+
+Browsers like Chrome and Firefox are forgiving: if your server sends an incomplete chain, they can often fetch the missing intermediate certificate from the AIA (Authority Information Access) extension at runtime and complete the chain themselves. **Your pages still load green.**
+
+Most server-side HTTP clients — including **Node.js `fetch` (undici)**, **Python `requests`**, **Go's `net/http`**, and others — do **not** do AIA fetching. They only trust what the OS/container trust store already has. If the intermediate is missing from both the server's response and the client's trust store, the TLS handshake fails.
+
+status-server runs inside a Node.js container and calls Omada controllers, webhooks, badge endpoints, and other HTTPS destinations via `fetch`. If any of those are fronted by a Caddy instance serving only the leaf certificate, status-server will log the cryptic error:
+
+```
+fetch failed
+```
+
+…with no HTTP status code, no SSL error detail, nothing. Browsers may work fine while status-server silently fails to reach the same URL.
+
+---
+
+## Symptoms
+
+- Omada controllers, webhooks, or custom HTTP checks keep flapping or show `DOWN` with no obvious reason
+- status-server logs show `fetch failed` (generic undici network error) with no HTTP code
+- The same URL works from:
+  - A browser
+  - `curl` on your laptop
+  - `wget` on the host machine (outside the container)
+- But the same URL fails from:
+  - `docker exec status-server wget <url>`
+  - `docker exec status-server node -e "fetch('<url>').then(r=>console.log(r.status))"`
+
+When your own hostname resolves to your own server's public IP, you might think it's a NAT hairpin issue — it usually isn't. It's almost always the TLS chain.
+
+---
+
+## Diagnosing the chain
+
+Run this from anywhere with `openssl`:
+
+```bash
+echo | openssl s_client -connect example.com:443 -servername example.com -showcerts 2>/dev/null \
+  | grep -cE "^-----BEGIN CERTIFICATE-----"
+```
+
+Interpret the count:
+
+| Count | Meaning |
+|:-:|---|
+| `0` | Can't reach the server at all (DNS / firewall / Caddy down) |
+| `1` | **Chain is incomplete** — only the leaf. Fix this. |
+| `2` | Leaf + intermediate. Normal and correct for most CAs. |
+| `3` | Leaf + two intermediates. Also fine — some CAs use two tiers. |
+
+If you want to see the actual certificate subjects:
+
+```bash
+echo | openssl s_client -connect example.com:443 -servername example.com -showcerts 2>/dev/null \
+  | grep -E "^(s:|i:)"
+```
+
+`s:` is subject, `i:` is issuer. The leaf's `i:` should match the intermediate's `s:`, and the intermediate's `i:` should match a root CA that's pre-installed on standard systems.
+
+---
+
+## Building `fullchain.pem` — the one file you actually need
+
+When your CA delivers certs, they usually give you three or four separate files:
+
+| File (common names) | What it is |
+|---|---|
+| `certificate.crt`, `<domain>.crt`, `cert.pem` | The leaf certificate (your domain) |
+| `ca_bundle.crt`, `<domain>.ca-bundle`, `chain.pem`, `intermediate.crt` | The intermediate CA cert |
+| `private.key`, `<domain>.key` | Your private key |
+| `fullchain.pem` *(not always provided — sometimes you have to build it)* | Leaf + intermediate concatenated |
+
+**`fullchain.pem` is just the leaf followed by the intermediate, in one PEM blob, in that order.**
+
+### PowerShell (Windows)
+
+```powershell
+Get-Content certificate.crt, ca_bundle.crt | Set-Content fullchain.pem
+```
+
+### CMD (Windows)
+
+```cmd
+type certificate.crt ca_bundle.crt > fullchain.pem
+```
+
+### bash / zsh (Linux, macOS)
+
+```bash
+cat certificate.crt ca_bundle.crt > fullchain.pem
+```
+
+### Manual (any OS, no terminal needed)
+
+1. Open `certificate.crt` in a text editor → copy all contents
+2. Open `ca_bundle.crt` in a text editor → copy all contents
+3. In a new file, paste the leaf first, then the intermediate below it
+4. Save as `fullchain.pem`
+
+Final file content should look like:
+
+```
+-----BEGIN CERTIFICATE-----
+MIID... (leaf cert for your.domain.com)
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIE... (intermediate CA cert)
+-----END CERTIFICATE-----
+```
+
+**Order matters.** Leaf first, intermediate second. If you swap them, Caddy will reject it with:
+
+```
+tls: private key does not match public key
+```
+
+…because Caddy treats the *first* certificate as "the certificate" and tries to match it against your private key — the intermediate's public key will never match your leaf's private key.
+
+---
+
+## Uploading to Caddy UI
+
+1. Caddy UI → **Certificates** → **Add Certificate** (or edit the existing one)
+2. Pick **Custom** (not Let's Encrypt)
+3. **Certificate** field → paste the contents of `fullchain.pem`
+4. **Certificate Key** field → paste the contents of `private.key`
+5. Save
+
+Then edit the relevant proxy host and select this certificate under **TLS Certificate**.
+
+---
+
+## Verifying after upload
+
+```bash
+echo | openssl s_client -connect your.domain.com:443 -servername your.domain.com -showcerts 2>/dev/null \
+  | grep -cE "^-----BEGIN CERTIFICATE-----"
+```
+
+Should now print `2` or more.
+
+From inside the status-server container:
+
+```bash
+docker exec status-server wget -qO- https://your.domain.com/some-path
+```
+
+Should return whatever the backend normally returns, without silent failure.
+
+---
+
+## The easier alternative: Auto SSL (Let's Encrypt)
+
+If your domain is publicly resolvable and port 80 is reachable from the internet, you can skip all of the above by letting Caddy issue certificates itself:
+
+- Caddy UI → edit proxy host → check **Auto SSL (Let's Encrypt)**
+- Leave the TLS Certificate dropdown alone
+- Save
+
+Caddy will automatically:
+- Issue the cert via ACME
+- Serve the full chain (no manual concat)
+- Auto-renew every ~60 days, forever
+
+Use a commercial/wildcard cert only when you specifically need one of:
+- **Wildcard coverage** (`*.example.com`) without paying for DNS-01 on every subdomain
+- **Hostnames that aren't public-resolvable** (internal DNS, LAN-only)
+- **An extended-validation (EV / OV) cert** for corporate/branding reasons
+- **CAs other than Let's Encrypt / ZeroSSL** (policy constraint)
+
+For most self-hosting cases, Auto SSL is strictly better.
+
+---
+
+## Renewal checklist
+
+Commercial certs typically expire every 90 days (ZeroSSL free tier) or 12 months (paid). When renewal time comes:
+
+1. Download the new cert bundle from your CA
+2. Rebuild `fullchain.pem` using the same command as above:
+   ```powershell
+   Get-Content certificate.crt, ca_bundle.crt | Set-Content fullchain.pem
+   ```
+3. Caddy UI → Certificates → edit the existing cert → replace the **Certificate** field contents with the new `fullchain.pem` contents
+4. Replace the **Certificate Key** field contents with the new `private.key` contents
+5. Save
+6. Verify:
+   ```bash
+   echo | openssl s_client -connect your.domain.com:443 -servername your.domain.com -showcerts 2>/dev/null \
+     | grep -cE "^-----BEGIN CERTIFICATE-----"
+   ```
+   Still `≥2`.
+
+Consider setting a reminder 2 weeks before expiry, and keep a small script or text note with the exact commands so you don't have to remember them each time.
+
+---
+
+## Troubleshooting
+
+**`tls: private key does not match public key`** when saving in Caddy UI
+→ The certs in your Certificate field are in the wrong order, or you pasted only the intermediate. Leaf must be first.
+
+**`fetch failed`** in status-server logs for specific hosts only
+→ Run the openssl chain check against those hosts. `1` = missing intermediate. Fix by building `fullchain.pem` and re-uploading.
+
+**Chain looks right via openssl but status-server still fails**
+→ Rare, but possible if the CA root itself isn't in your status-server container's trust store. Rebuild with an updated `ca-certificates` package, or set **Verify TLS off** on that specific check as a fallback (Admin → edit the check → uncheck Verify TLS).
+
+**Browser works, `curl` works, but Node/status-server fails**
+→ Classic symptom of missing intermediate. Browsers do AIA fetching, curl uses the system trust store (which may include more CAs than the container), Node's undici is strict and uses only what's in the container image. Fix the chain.
+
+---
+
+## Background: why server-side clients are stricter
+
+When a TLS server presents a certificate, it's *supposed* to send:
+
+1. The leaf cert (its own)
+2. Every intermediate cert needed to chain up to a trusted root
+3. **NOT** the root itself (the client already has it)
+
+If the server only sends #1, the client has to figure out #2 on its own. The leaf's AIA extension contains a URL where the intermediate can be downloaded — browsers do this automatically. Most server-side HTTP libraries consider it too slow / risky / unnecessary and skip it.
+
+Sending the correct chain is the server's responsibility. Caddy can't do it for you if you upload only a leaf cert.
+
+This is also why Let's Encrypt's certbot saves `fullchain.pem` by default — it's trying to save you from this exact class of bug.


### PR DESCRIPTION
## Summary
- Detect Omada-rejected access tokens (HTTP 401/403, errorCodes -44104/-44109/-44112/-44113, or msg matching \"access token\" + expired/invalid/refreshToken), drop the cached token, and retry once with a fresh one.
- Refactored shared auth/retry into `omadaAuthedGet` so both standard and MSP API paths benefit.
- Add `.github/workflows/preview.yml`: manual `workflow_dispatch` that builds linux/amd64 only and pushes `applegater/status-server:preview` (plus a `preview-<short-sha>` pin) for Portainer preview deploys.

## Why
After rebooting the Omada controller, all checks failed for up to ~2h with \"The access token has expired. Please re-initiate the refreshToken process...\" because the in-memory cache still considered the old token valid until its original `expiresIn` elapsed. Now the next check transparently re-auths.

## Test plan
- [ ] Reboot Omada controller, confirm next status check succeeds within one cycle (no 2h stall)
- [ ] Confirm normal (non-rebooted) checks still pass and don't pay an extra round-trip
- [ ] Dispatch \"Preview Docker Build\" workflow → verify `applegater/status-server:preview` appears on Docker Hub
- [ ] Pull `:preview` in Portainer, smoke-test the UI